### PR TITLE
adding react-spinner-kit library

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-dom": "^16.8.6"
   },
   "dependencies": {
-    "react-spinners": "^0.5.4"
+    "react-spinners-kit": "^1.9.0",
+    "styled-components": "^4.3.1"
   }
 }

--- a/src/spinnerContainer/SpinnerContainer.css
+++ b/src/spinnerContainer/SpinnerContainer.css
@@ -7,7 +7,7 @@
 	position: absolute;
 	z-index: 999;
 	left: 45%;
-	top: 45%;
+	top: 40%;
 }
 
 .spinner-content {

--- a/src/spinnerContainer/SpinnerContainer.js
+++ b/src/spinnerContainer/SpinnerContainer.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { ClipLoader } from 'react-spinners';
+import { CircleSpinner } from "react-spinners-kit";
 import './SpinnerContainer.css';
 
 export default class SpinnerContainer extends Component {
@@ -29,7 +29,7 @@ export default class SpinnerContainer extends Component {
     return (
       <div className='spinner-container'>
         <div className='spinner'>
-          <ClipLoader color={this.props.color} loading={this.state.loading} />
+          <CircleSpinner color={this.props.color} loading={this.state.loading} />
         </div>
         <div className={spinnerContentClass}>
           {this.props.children}


### PR DESCRIPTION
Replacing spinner library to get around the 'super' bug we were encountering in other components. Turns out, the dependency on 'recompose' in the react-spinners component was the source of the issue... new library (react-spinners-kit) does not have this dependency